### PR TITLE
Remove data files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-data/geolines.geojson filter=lfs diff=lfs merge=lfs -text
-data/geopolys.geojson filter=lfs diff=lfs merge=lfs -text

--- a/data/geolines.geojson
+++ b/data/geolines.geojson
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eed226d7ed01ddcaddd0151260d719fdaf12ebdf389746d0ceb22ccf903c2495
-size 306485548

--- a/data/geopolys.geojson
+++ b/data/geopolys.geojson
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:42b7249b27b17387578ea46f77495f48c9a319f0d5d16ce06c393b1f41bf4591
-size 516428509


### PR DESCRIPTION
The geojson files are too large to be managed with git-lfs -- unless I'm willing to pay for it. I'll be moving the data files out of this repository, though they'll still be available for download, just hosted elsewhere.